### PR TITLE
Typo nomenclatures

### DIFF
--- a/contrib/m_sipaf/backend/m_sipaf/migrations/versions/c11d028e1b42_typo_nomenclature.py
+++ b/contrib/m_sipaf/backend/m_sipaf/migrations/versions/c11d028e1b42_typo_nomenclature.py
@@ -1,0 +1,62 @@
+"""typo_nomenclature
+
+Revision ID: c11d028e1b42
+Revises: b7eb2e900bf1
+Create Date: 2024-01-09 20:29:26.613697
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "c11d028e1b42"
+down_revision = "7664e8f989f1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+
+    ALTER TABLE pr_sipaf.t_diagnostics
+        DROP CONSTRAINT check_nom_type_diag_amenagement_entretient;
+
+    ALTER TABLE pr_sipaf.t_diagnostics
+        RENAME COLUMN id_nomenclature_amenagement_entretient
+         TO id_nomenclature_amenagement_entretien;
+
+    ALTER TABLE pr_sipaf.t_diagnostics
+        ADD CONSTRAINT check_nom_type_diag_amenagement_entretien CHECK (
+            ref_nomenclatures.check_nomenclature_type_by_mnemonique(
+                id_nomenclature_amenagement_entretien,
+                'PF_DIAG_AMENAGEMENT_ENTRETIEN'
+            )
+        ) NOT VALID;
+
+    """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+
+    ALTER TABLE pr_sipaf.t_diagnostics
+        DROP CONSTRAINT check_nom_type_diag_amenagement_entretien;
+
+    ALTER TABLE pr_sipaf.t_diagnostics
+        RENAME COLUMN id_nomenclature_amenagement_entretien
+         TO id_nomenclature_amenagement_entretient;
+
+    ALTER TABLE pr_sipaf.t_diagnostics
+        ADD CONSTRAINT check_nom_type_diag_amenagement_entretient CHECK (
+            ref_nomenclatures.check_nomenclature_type_by_mnemonique(
+                id_nomenclature_amenagement_entretient,
+                'PF_DIAG_AMENAGEMENT_ENTRETIENT'
+            )
+        ) NOT VALID;
+
+    """
+    )

--- a/contrib/m_sipaf/backend/m_sipaf/models.py
+++ b/contrib/m_sipaf/backend/m_sipaf/models.py
@@ -399,11 +399,11 @@ class Diagnostic(db.Model):
         TNomenclatures, secondary=CorDiagAmenagementBiodiv.__table__
     )
 
-    id_nomenclature_amenagement_entretient = db.Column(
+    id_nomenclature_amenagement_entretien = db.Column(
         db.Integer, db.ForeignKey("ref_nomenclatures.t_nomenclatures.id_nomenclature")
     )
-    nomenclature_amenagement_entretient = db.relationship(
-        TNomenclatures, foreign_keys=[id_nomenclature_amenagement_entretient]
+    nomenclature_amenagement_entretien = db.relationship(
+        TNomenclatures, foreign_keys=[id_nomenclature_amenagement_entretien]
     )
 
     commentaire_amenagement = db.Column(db.Unicode)

--- a/contrib/m_sipaf/config/definitions/m_sipaf.diag.schema.yml
+++ b/contrib/m_sipaf/config/definitions/m_sipaf.diag.schema.yml
@@ -71,6 +71,8 @@ properties:
   vegetation_debouche:
     title: Vegetation (débouchés)
     description: Végétation présente aux débouchés de l'ouvrage
+  id_nomenclature_amenagement_entretien:
+    title: Entretien dispositif et végétation
   commentaire_amenagement:
     title: Commentaire (aménagement)
     description: champs libre pour information complémentaire indicative

--- a/contrib/m_sipaf/config/features/m_sipaf.utils.data.yml
+++ b/contrib/m_sipaf/config/features/m_sipaf.utils.data.yml
@@ -23,9 +23,9 @@ items:
       source: SIPAF
     items:
       - [PF_OUVRAGE_MATERIAUX, Matériaux, "Matériaux composant l'ouvrage"]
-      - [PF_OUVRAGE_HYDRAULIQUE_POSITION, OH Position, "Position de l'ouvrage hydrolique"]
+      - [PF_OUVRAGE_HYDRAULIQUE_POSITION, OH Position, "Position de l'ouvrage hydraulique"]
       - [PF_OUVRAGE_HYDRAULIQUE_BANQ_CARACT, OH Caractérisation banquette, Caractérisation de la banquette pour un ouvrage hydraulique]
-      - [PF_OUVRAGE_HYDRAULIQUE_BANQ_TYPE, OH Type de banquette, Type de banquette pour un ouvrage hydrolique]
+      - [PF_OUVRAGE_HYDRAULIQUE_BANQ_TYPE, OH Type de banquette, Type de banquette pour un ouvrage hydraulique]
       - [PF_INFRASTRUCTURE_TYPE, "Type d'infrastructure", "Type d'infrastructure pour les passages à faune"]
       - [PF_OUVRAGE_SPECIFICITE, Spécificité, Exclusivité du passage pour le passage de la faune]
       - [PF_OUVRAGE_TYPE, "Type d'ouvrage", "Type d'ouvrage d'art pour le passage faune"]
@@ -41,7 +41,7 @@ items:
       - [PF_DIAG_CLOTURES_GUIDAGE_ETAT, État des clôtures, État des clôtures pouvant guider les animaux vers le passage]
       - [PF_DIAG_AMENAGEMENT_VEGETATION_TYPE, Type de végétation, Type de végétation présente]
       - [PF_DIAG_AMENAGEMENT_VEGETATION_COUVERT, Couverture végétale (%), Couverture végétale (%)]
-      - [PF_DIAG_AMENAGEMENT_ENTRETIENT, Entretient dispositif et végétation, Entretient dispositif et végétation]
+      - [PF_DIAG_AMENAGEMENT_ENTRETIENT, Entretien dispositif et végétation, Entretien dispositif et végétation]
       - [PF_DIAG_FRANCHISSABILITE, Franchissabilité, Estimation de la franchissabilité de l'ouvrage pour les animaux]
       - [PF_DIAG_INTERET_FAUNE, Intérêt pour les espèces cibles, Intérêt pour les espèces cibles]
       - [PF_USAGE_CATEGORIE, Catégorie d'usage, Attribut définissant le type d'usage en dehors du passage de la faune (type de mixité)]
@@ -79,7 +79,7 @@ items:
       - [PF_INFRASTRUCTURE_TYPE, RN, R. N., Route Nationale, Route Nationale]
       - [PF_INFRASTRUCTURE_TYPE, RD, R. D., Route Départementale, Route Départementale]
       - [PF_INFRASTRUCTURE_TYPE, VF, V. F., Voie ferrée, Voie ferrée]
-      - [PF_INFRASTRUCTURE_TYPE, CA, Ca., Canal / Rivère navigable, Canal / Rivère navigable]
+      - [PF_INFRASTRUCTURE_TYPE, CA, Ca., Canal / Rivière navigable, Canal / Rivière navigable]
 
       - [PF_OUVRAGE_SPECIFICITE, MIX, Mixt., Mixte, Ouvrage mixte construit pour le passage des animaux concomitamment à un ou plusieurs autres usages]
       - [PF_OUVRAGE_SPECIFICITE, ND, Non déd., Non dédié, Ouvrage non dédié au passage de la faune mais pouvant servir à cet usage]
@@ -111,7 +111,7 @@ items:
       - [PF_OUVRAGE_CATEGORIE, SPE_CANOP, Spé. Canop., "Ouvrage spécifique: passage canopée", "Ouvrage spécifique: passage canopée"]
 
       - [PF_TYPE_ACTOR, PRO, Prop., Propriétaire, Propriétaire]
-      - [PF_TYPE_ACTOR, CON, Conc., Concessionaire, Concessionnaire]
+      - [PF_TYPE_ACTOR, CON, Conc., Concessionnaire, Concessionnaire]
       - [PF_TYPE_ACTOR, INT, Int., Intervenant, Intervenant sur ce passage faune]
       - [PF_TYPE_ACTOR, GES, Ges., Gestionnaire, Gestionnaire du passage faune]
       - [PF_TYPE_ACTOR, ETA, État, État, État]
@@ -183,12 +183,12 @@ items:
 
       - [PF_DIAG_AMENAGEMENT_ENTRETIENT, BON, Bon., Bonne, Bonne]
       - [PF_DIAG_AMENAGEMENT_ENTRETIENT, MOY, Moy., Moyenne, Moyenne]
-      - [PF_DIAG_AMENAGEMENT_ENTRETIENT, OCC, Occ., Occasionelle, Occasionelle]
+      - [PF_DIAG_AMENAGEMENT_ENTRETIENT, OCC, Occ., Occasionnelle, Occasionnelle]
       - [PF_DIAG_AMENAGEMENT_ENTRETIENT, NUL, Nul., Nulle, Nulle]
 
       - [PF_DIAG_FRANCHISSABILITE, BON, Bon., Bonne, Bonne]
       - [PF_DIAG_FRANCHISSABILITE, MOY, Moy., Moyenne, Moyenne]
-      - [PF_DIAG_FRANCHISSABILITE, OCC, Occ., Occasionelle, Occasionelle]
+      - [PF_DIAG_FRANCHISSABILITE, OCC, Occ., Occasionnelle, Occasionnelle]
       - [PF_DIAG_FRANCHISSABILITE, NUL, Nul., Nulle, Nulle]
 
       - [PF_DIAG_INTERET_FAUNE, FAI, Fai., Faible, Faible]

--- a/contrib/m_sipaf/config/features/m_sipaf.utils.data.yml
+++ b/contrib/m_sipaf/config/features/m_sipaf.utils.data.yml
@@ -41,7 +41,7 @@ items:
       - [PF_DIAG_CLOTURES_GUIDAGE_ETAT, État des clôtures, État des clôtures pouvant guider les animaux vers le passage]
       - [PF_DIAG_AMENAGEMENT_VEGETATION_TYPE, Type de végétation, Type de végétation présente]
       - [PF_DIAG_AMENAGEMENT_VEGETATION_COUVERT, Couverture végétale (%), Couverture végétale (%)]
-      - [PF_DIAG_AMENAGEMENT_ENTRETIENT, Entretien dispositif et végétation, Entretien dispositif et végétation]
+      - [PF_DIAG_AMENAGEMENT_ENTRETIEN, Entretien dispositif et végétation, Entretien dispositif et végétation]
       - [PF_DIAG_FRANCHISSABILITE, Franchissabilité, Estimation de la franchissabilité de l'ouvrage pour les animaux]
       - [PF_DIAG_INTERET_FAUNE, Intérêt pour les espèces cibles, Intérêt pour les espèces cibles]
       - [PF_USAGE_CATEGORIE, Catégorie d'usage, Attribut définissant le type d'usage en dehors du passage de la faune (type de mixité)]
@@ -181,10 +181,10 @@ items:
       - [PF_DIAG_AMENAGEMENT_VEGETATION_COUVERT, "3", 50-75, 50-75 %, 50-75 %]
       - [PF_DIAG_AMENAGEMENT_VEGETATION_COUVERT, "4", 75-100, 75-100 %, 75-100 %]
 
-      - [PF_DIAG_AMENAGEMENT_ENTRETIENT, BON, Bon., Bonne, Bonne]
-      - [PF_DIAG_AMENAGEMENT_ENTRETIENT, MOY, Moy., Moyenne, Moyenne]
-      - [PF_DIAG_AMENAGEMENT_ENTRETIENT, OCC, Occ., Occasionnelle, Occasionnelle]
-      - [PF_DIAG_AMENAGEMENT_ENTRETIENT, NUL, Nul., Nulle, Nulle]
+      - [PF_DIAG_AMENAGEMENT_ENTRETIEN, BON, Bon., Bonne, Bonne]
+      - [PF_DIAG_AMENAGEMENT_ENTRETIEN, MOY, Moy., Moyenne, Moyenne]
+      - [PF_DIAG_AMENAGEMENT_ENTRETIEN, OCC, Occ., Occasionnelle, Occasionnelle]
+      - [PF_DIAG_AMENAGEMENT_ENTRETIEN, NUL, Nul., Nulle, Nulle]
 
       - [PF_DIAG_FRANCHISSABILITE, BON, Bon., Bonne, Bonne]
       - [PF_DIAG_FRANCHISSABILITE, MOY, Moy., Moyenne, Moyenne]

--- a/contrib/m_sipaf/config/layouts/m_sipaf.diagnostic_edit.layout.yml
+++ b/contrib/m_sipaf/config/layouts/m_sipaf.diagnostic_edit.layout.yml
@@ -92,6 +92,7 @@ aliases:
         items:
           - id_nomenclature_vegetation_type
           - id_nomenclature_vegetation_couvert
+    - id_nomenclature_amenagement_entretien
     - key: commentaire_amenagement
       type: textarea
 

--- a/contrib/m_sipaf/doc/import_passage_faune_description_champs.md
+++ b/contrib/m_sipaf/doc/import_passage_faune_description_champs.md
@@ -180,7 +180,7 @@
   - *champ(s)* : `cd_nomenclature`
   - *valeurs* :
     - **PRO** *Propriétaire*
-    - **CON** *Concessionaire*
+    - **CON** *Concessionnaire*
     - **INT** *Intervenant*
     - **GES** *Gestionnaire*
     - **ETA** *État*

--- a/doc/import.md
+++ b/doc/import.md
@@ -71,7 +71,7 @@ où `pre_process` est une vue qui va transformer les colonnes du fichier csv en 
 SELECT
 	uuid_pf AS id_passage_faune,
 	CASE
-		WHEN type_role_org = 'Concessionaire' THEN 'CON'
+		WHEN type_role_org = 'Concessionnaire' THEN 'CON'
 		WHEN type_role_org = 'ETAT' THEN 'ETA'
 		WHEN type_role_org = 'Département' THEN 'DEP'
 		WHEN type_role_org = 'Gestionnaire' THEN 'GES'


### PR DESCRIPTION
De ce que j'ai compris, les nomenclatures seront mises à jour automatiquement en mettant à jour le module avec la version incluant ces corrections.

Pour aller au bout, il faudrait aussi renommer le type de nomenclatures "PF_DIAG_AMENAGEMENT_ENTRETIENT" en "PF_DIAG_AMENAGEMENT_ENTRETIEN" (sans T à la fin d'entretien), mais ça s'est surement moins automatique et moins important car les utilisateurs ne le verront pas.
Et y a des répercussions dans le SQL, etc... (https://github.com/search?q=repo%3APnX-SI%2Fgn_modulator%20entretient&type=code) donc peut-être trop complexe ou pour plus tard.